### PR TITLE
Jsx support

### DIFF
--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -196,19 +196,15 @@ exports.init = function(grunt) {
       // translation to properly report the original source file and
       // clean up when finished.
       files = grunt.util._.map(files, function(file) {
-        if (path.extname(file) === '.jsx') {
-          var jsx = grunt.file.read(file);
-          try {
-            var js = React.transform(jsx);
-            var tmpfile = path.join(os.tmpdir(), 'grunt-jsxhint', file);
-            tempFiles[tmpfile] = file;
-            grunt.file.write(tmpfile, js);
-            return tmpfile;
-          } catch (err) {
-            grunt.log.warn('error converting ' + file + ': ' + err);
-            return file;
-          }
-        } else {
+        var jsx = grunt.file.read(file);
+        try {
+          var js = React.transform(jsx);
+          var tmpfile = path.join(os.tmpdir(), 'grunt-jsxhint', file);
+          tempFiles[tmpfile] = file;
+          grunt.file.write(tmpfile, js);
+          return tmpfile;
+        } catch (err) {
+          grunt.log.warn('error converting ' + file + ': ' + err);
           return file;
         }
       });


### PR DESCRIPTION
Hello :-)

I know that the PR for this branch on `grunt-contrib-jshint` has been rejected but I wanted to let you know that I like your fork to bring the support for JSX,

I brought some changes: the React tools seem to ignore the transformation unless it have the `/** @jsx React.DOM */` comment and even if the file is .jsx so I fixed that you can both use `.js` or `jsx`.
I personally prefer to use `.js` because it works better with Browserify (you explicitely need to do `require("./foo/index.jsx")` otherwise..

BTW I think we should create `grunt-contrib-jsxhint` on NPM

Cheers
