### PR TITLE
Flexible jsx extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,12 @@ Specify a filepath to output the results of a reporter. If `reporterOutput` is s
 
 #### convertJSX
 
-Type: `Boolean`  
+Type: `Boolean` or `String`
 Default: `false`
 
 Convert [Facebook React](https://github.com/facebook/react) .jsx files into javascript before calling jshint on them.
+
+By default, only files with the extension `jsx` are converted. By specifying an alternate extension (without leading period -- such as `jsx.js`), those files will be converted instead.
 
 ### Usage examples
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "hooker": "~0.2.3",
     "jshint": "~2.5.0",
-    "react-tools": "^0.11.1"
+    "react-tools": "^0.12.2"
   },
   "devDependencies": {
     "grunt-contrib-nodeunit": "~0.3.1",

--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -191,12 +191,19 @@ exports.init = function(grunt) {
     }
 
     var tempFiles = {};
-    if (options.convertJSX === true) {
+    if (options.convertJSX === true || typeof options.convertJSX === 'string') {
+      var JSXextension = '.jsx';
+
+      // Allow overriding of the JSX extension, by passing a string to convertJSX.
+      if (typeof options.convertJSX === 'string') {
+        JSXextension = '.' + options.convertJSX;
+      }
+
       // Convert any jsx files into js files, keeping track of the
       // translation to properly report the original source file and
       // clean up when finished.
       files = grunt.util._.map(files, function(file) {
-        if (path.extname(file) === '.jsx') {
+        if (file.lastIndexOf(JSXextension) === file.length - JSXextension.length) {
           var jsx = grunt.file.read(file);
           try {
             var js = React.transform(jsx);

--- a/test/fixtures/valid.jsx.js
+++ b/test/fixtures/valid.jsx.js
@@ -1,0 +1,3 @@
+/** @jsx React.DOM */
+var hello = "Hello World";
+var link = <a href="http://nowhere.com">{hello}</a>;

--- a/test/jshint_test.js
+++ b/test/jshint_test.js
@@ -163,12 +163,25 @@ exports.jshint = {
     });
   },
   validJSX: function(test) {
-    test.expect(1);
+    test.expect(2);
     var files = [path.join(fixtures, 'valid.jsx')];
     var options = {
       convertJSX: true
     };
     jshint.lint(files, options, function(results, data) {
+      test.equal(data.length, 1, 'Should have linted the file passed to jshint.');
+      test.ok(results.length === 0, 'Should not have reported any errors with supplied .jshintrc');
+      test.done();
+    });
+  },
+  validJSXdotJS: function(test) {
+    test.expect(2);
+    var files = [path.join(fixtures, 'valid.jsx.js')];
+    var options = {
+      convertJSX: 'jsx.js'
+    };
+    jshint.lint(files, options, function(results, data) {
+      test.equal(data.length, 1, 'Should have linted the file passed to jshint.');
       test.ok(results.length === 0, 'Should not have reported any errors with supplied .jshintrc');
       test.done();
     });


### PR DESCRIPTION
We use the extension `.jsx.js` on our project, this adds support for any extensions arbitrarily.

Note it also updates the `react-tools` dependency to 0.12.2, which removes the need for the `@jsx React.DOM` header but also recommends using the regular `.jsx` extension.

n.b. it turns out JSXTransformer will always output double-quoted `"strings"`, which conflicts with our project's code style, so we decided against integrating `jshint-jsx` into our workflow in the end. The code is tested but up to you whether the feature may help others.